### PR TITLE
Also publish container image to Docker Hub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,9 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
+    tags:
+      - '*'
 
 jobs:
   goreleaser:
@@ -18,6 +19,9 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.14.x
+
+      - name: Login to Docker Hub Registry
+        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
       - name: Login to GitHub Package Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u "${{ github.actor }}" --password-stdin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,10 @@ dockers:
       - "docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app:v{{ .Major }}"
       - "docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app:v{{ .Major }}.{{ .Minor }}"
       - "docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app:latest"
+      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:{{ .Tag }}"
+      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:v{{ .Major }}"
+      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:v{{ .Major }}.{{ .Minor }}"
+      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:latest"
     build_flag_templates:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"


### PR DESCRIPTION
Publishing to Docker Hub makes pulling the image easy because you can skip creating a pull secret.
GitHub Packages still don't support anonymous pulling.