### PR TITLE
:sparkles: (Dockerfile) Switched to numeric user id in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM scratch
 COPY potz-holzoepfel-und-zipfelchape /
 COPY etc/passwd /etc/passwd
 
-USER nobody
+USER 65534
 
 ENTRYPOINT ["/potz-holzoepfel-und-zipfelchape"]


### PR DESCRIPTION
Running the container under a restricted Pod Security Policy requires a numeric userid