### PR TITLE
chore(container-image): migrate to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,20 +11,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
           go-version: 1.15.x
 
-      - name: Login to Docker Hub Registry
-        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-
-      - name: Login to GitHub Package Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u "${{ github.actor }}" --password-stdin
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,12 @@ jobs:
         with:
           go-version: 1.15.x
 
-      - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,14 +23,10 @@ changelog:
     - '^test:'
 dockers:
   - image_templates:
-      - "docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app:{{ .Tag }}"
-      - "docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app:v{{ .Major }}"
-      - "docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app:v{{ .Major }}.{{ .Minor }}"
-      - "docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app:latest"
-      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:{{ .Tag }}"
-      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:v{{ .Major }}"
-      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:v{{ .Major }}.{{ .Minor }}"
-      - "docker.io/adfinissygroup/potz-holzoepfel-und-zipfelchape:latest"
+      - "ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape:{{ .Tag }}"
+      - "ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape:v{{ .Major }}"
+      - "ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape:v{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape:latest"
     build_flag_templates:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Tri Tra Trulla La!
 ## Usage
 
 Run an `potz-holzoepfel-und-zipfelchape` binary from the [releases page](https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/releases) or use
-the container available at `docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app`.
+the container available at `ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape`.
 
 ```bash
-docker run --rm -ti -p 8080:8080 docker.pkg.github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape/app
+docker run --rm -ti -p 8080:8080 ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape
 ```
 
 Get page contents:


### PR DESCRIPTION
Replaces #11 

~~Needs a `CR_TOKEN` and `CR_USER` GitHub Actions secret to push the container image. Other API access is stil done via the built-in `GITHUB_TOKEN`.~~

* [x] ~~set up `CR_TOKEN` and `CR_USER` secrets~~