### PR TITLE
Add OK output to /healthz when healthy

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -149,7 +149,10 @@ func index(template *template.Template, counterHandle counterHandler) http.Handl
 func healthz() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if atomic.LoadInt32(&healthy) == 1 {
-			w.WriteHeader(http.StatusNoContent)
+			_, err := w.Write([]byte("OK"))
+			if err != nil {
+				log.Fatal(err)
+			}
 			return
 		}
 		w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
Some loadbalancers (e.g. Google Cloud Load Balancer) don't accept a HTTP status code of 204 No
Content as healthy so we've decided to return 200 OK and the string OK instead.