### PR TITLE
refactor(mongodb): replace deprecated DurationNanos with Duration

### DIFF
--- a/pkg/mongodb/tracer/tracer.go
+++ b/pkg/mongodb/tracer/tracer.go
@@ -49,7 +49,7 @@ func (t *tracer) HandleSucceededEvent(ctx context.Context, evt *event.CommandSuc
 		if span, ok := rawSpan.(opentracing.Span); ok {
 			defer span.Finish()
 			span.SetTag(prefix+"reply", string(evt.Reply))
-			span.SetTag(prefix+"duration", evt.DurationNanos)
+			span.SetTag(prefix+"duration", evt.Duration)
 		}
 	}
 }
@@ -63,7 +63,7 @@ func (t *tracer) HandleFailedEvent(ctx context.Context, evt *event.CommandFailed
 		if span, ok := rawSpan.(opentracing.Span); ok {
 			defer span.Finish()
 			ext.Error.Set(span, true)
-			span.SetTag(prefix+"duration", evt.DurationNanos)
+			span.SetTag(prefix+"duration", evt.Duration)
 			span.LogFields(log.String("failure", evt.Failure))
 		}
 	}


### PR DESCRIPTION
~~This probably changes the content of the `duration` tag in the span, as the variable type changes from [`int64`](https://pkg.go.dev/builtin#int64) to [`time.Duration`](https://pkg.go.dev/time#Duration).~~

Forget what I said, they're both `int64` in the end.