### PR TITLE
fix(goreleaser): remove deprecated archives.replacements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,12 +5,13 @@ builds:
 - env:
   - CGO_ENABLED=0
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+- name_template: >-
+    {{- .ProjectName }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
+    {{- if .Arm }}v{{ .Arm }}{{ end -}}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
According to [their deprecation docs](https://goreleaser.com/deprecations/?h=replacements#archivesreplacements) this should result in the same release assets.